### PR TITLE
Update atuin_loader.fish

### DIFF
--- a/conf.d/atuin_loader.fish
+++ b/conf.d/atuin_loader.fish
@@ -4,6 +4,6 @@ functions --query \
 
 ### Set variables on load ###
 # whether or not atuin has been loaded
-_atuin_loader_load false
+set -gx _atuin_loader_load false
 # arguments to pass to `atuin init fish`
-_atuin_loader_arguments ""
+set -gx _atuin_loader_arguments ""

--- a/conf.d/atuin_loader.fish
+++ b/conf.d/atuin_loader.fish
@@ -4,6 +4,6 @@ functions --query \
 
 ### Set variables on load ###
 # whether or not atuin has been loaded
-set -gx _atuin_loader_load false
+set --global _atuin_loader_load false
 # arguments to pass to `atuin init fish`
-set -gx _atuin_loader_arguments ""
+set --global _atuin_loader_arguments ""


### PR DESCRIPTION
Fix Unknown command error on install and startup

```
fisher install version 4.4.5
Fetching https://api.github.com/repos/dudeofawesome/fish-plugin-atuin-loader/tarball/HEAD
Installing dudeofawesome/fish-plugin-atuin-loader
           /home/erikkallen/.config/fish/functions/_atuin_loader_load.fish
           /home/erikkallen/.config/fish/conf.d/atuin_loader.fish
fish: Unknown command: _atuin_loader_arguments
~/.config/fish/conf.d/atuin_loader.fish (line 9): 
_atuin_loader_arguments ""
^~~~~~~~~~~~~~~~~~~~~~^
from sourcing file ~/.config/fish/conf.d/atuin_loader.fish
	called on line 189 of file /usr/share/fish/vendor_functions.d/fisher.fish
in function 'fisher' with arguments 'install dudeofawesome/fish-plugin-atuin-loader'
Installed 1 plugin/s
```