### PR TITLE
Update atuin_loader.fish

### DIFF
--- a/conf.d/atuin_loader.fish
+++ b/conf.d/atuin_loader.fish
@@ -3,7 +3,8 @@ functions --query \
     _atuin_loader_load
 
 ### Set variables on load ###
-# whether or not atuin has been loaded
-set --global _atuin_loader_load false
 # arguments to pass to `atuin init fish`
-set --global _atuin_loader_arguments ""
+set _atuin_loader_arguments
+
+# whether or not atuin has been loaded
+_atuin_loader_load false


### PR DESCRIPTION
Sorry to bother once more, don't really know why this worked the last time, but I spent some time actually figuring out how fish works and this is the proper fix.
The arguments where set after calling the function, this does not work.
Now the global flag is not even needed