### PR TITLE
Fixed Loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
-# `fish-plugin-atuin-loader` [![GPL-3 License](https://img.shields.io/badge/license-GPL3-007EC7.svg?style=flat-square)](/LICENSE)
+# fish-plugin-atuin-loader
 
-> A [Fish shell](https://fishshell.com/) plugin to load [Atuin](https://github.com/atuinsh/atuin) on interactive shell start.
+Auto-loads [Atuin](https://github.com/atuinsh/atuin) when you start a new Fish shell.
 
 ## Installation
 
 ```fish
-$ fisher install dudeofawesome/fish-plugin-atuin-loader
+fisher install dudeofawesome/fish-plugin-atuin-loader
 ```
 
 ## Usage
 
-1. Start a new shell and witness Atuin load.
+Just start a new shell - Atuin loads automatically.
+
+To pass custom arguments to atuin:
+
+```fish
+set -U _atuin_loader_arguments --disable-up-arrow
+```
 
 ## Development
 

--- a/conf.d/atuin_loader.fish
+++ b/conf.d/atuin_loader.fish
@@ -1,9 +1,5 @@
-### Load functions ###
-functions --query \
-    _atuin_loader_load
-
-### Set variables on load ###
-# whether or not atuin has been loaded
-set --global _atuin_loader_load false
-# arguments to pass to `atuin init fish`
-set --global _atuin_loader_arguments ""
+### Auto-load Atuin ###
+# Only load if we're in an interactive session
+if status is-interactive
+    _atuin_loader_load false  # false = disable loading message for cleaner startup
+end

--- a/functions/_atuin_loader_load.fish
+++ b/functions/_atuin_loader_load.fish
@@ -11,9 +11,9 @@ function _atuin_loader_load \
     if command -v atuin >/dev/null 2>&1
         # Load atuin with any custom arguments
         if set -q _atuin_loader_arguments; and test (count $_atuin_loader_arguments) -gt 0
-            atuin init fish $_atuin_loader_arguments | sed 's/-k up/up/' | source
+            atuin init fish $_atuin_loader_arguments | source
         else
-            atuin init fish | sed 's/-k up/up/' | source
+            atuin init fish | source
         end
         
         if test "$enable_logging" != false

--- a/functions/_atuin_loader_load.fish
+++ b/functions/_atuin_loader_load.fish
@@ -1,21 +1,27 @@
 function _atuin_loader_load \
     --description "Loads the Atuin fish plugin"
 
+    # Parse arguments
     set enable_logging $argv[1]
     if not set --query argv[1]
-        set --function enable_logging true
+        set enable_logging true
     end
 
-    if status is-interactive; and which atuin >/dev/null
-        atuin init fish $_atuin_loader_arguments | source
-
-        if "$enable_logging" != false
+    # Check if atuin is available
+    if command -v atuin >/dev/null 2>&1
+        # Load atuin with any custom arguments
+        if set -q _atuin_loader_arguments[1]
+            atuin init fish $_atuin_loader_arguments | source
+        else
+            atuin init fish | source
+        end
+        
+        if test "$enable_logging" != false
             echo "Loaded the Atuin fish plugin."
         end
     else
-        if "$enable_logging" != false
-            echo "Skipped loading the Atuin fish plugin."
+        if test "$enable_logging" != false
+            echo "Skipped loading Atuin: atuin command not found."
         end
     end
-
 end

--- a/functions/_atuin_loader_load.fish
+++ b/functions/_atuin_loader_load.fish
@@ -10,7 +10,7 @@ function _atuin_loader_load \
     # Check if atuin is available
     if command -v atuin >/dev/null 2>&1
         # Load atuin with any custom arguments
-        if set -q _atuin_loader_arguments[1]
+        if set -q _atuin_loader_arguments; and test (count $_atuin_loader_arguments) -gt 0
             atuin init fish $_atuin_loader_arguments | source
         else
             atuin init fish | source

--- a/functions/_atuin_loader_load.fish
+++ b/functions/_atuin_loader_load.fish
@@ -11,9 +11,9 @@ function _atuin_loader_load \
     if command -v atuin >/dev/null 2>&1
         # Load atuin with any custom arguments
         if set -q _atuin_loader_arguments; and test (count $_atuin_loader_arguments) -gt 0
-            atuin init fish $_atuin_loader_arguments | source
+            atuin init fish $_atuin_loader_arguments | sed 's/-k up/up/' | source
         else
-            atuin init fish | source
+            atuin init fish | sed 's/-k up/up/' | source
         end
         
         if test "$enable_logging" != false


### PR DESCRIPTION
- `_atuin_loader_load` was never called in conf.d/atuin_loader.fish. Fixed it.
- Added check, if `$_atuin_loader_arguments` is set but empty before passing it to `atuin init fish`.
- Removed variable creation from conf.d/atuin_loader.fish. Not needed.
- Added example, how to use `$_atuin_loader_arguments` to the readme.

